### PR TITLE
Fix PUT json response not valid

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,5 @@
-===============================
 pluralsight
-===============================
+===========
 
 .. image:: https://img.shields.io/pypi/v/pluralsight.svg
         :target: https://pypi.python.org/pypi/pluralsight

--- a/pluralsight/__init__.py
+++ b/pluralsight/__init__.py
@@ -16,4 +16,4 @@
 
 __author__ = 'Anthony Shaw'
 __email__ = 'anthonyshaw@apache.org'
-__version__ = '1.0.0'
+__version__ = '1.1.0'

--- a/pluralsight/licensing/client.py
+++ b/pluralsight/licensing/client.py
@@ -77,8 +77,6 @@ class LicensingAPIClient(object):
             result = self.session.put("{0}/{1}".format(self.base_url, uri),
                                       json=data)
             result.raise_for_status()
-
-            return result.json()
         except requests.HTTPError as e:
             raise PluralsightApiException(e.response.text)
 

--- a/pluralsight/licensing/invites.py
+++ b/pluralsight/licensing/invites.py
@@ -108,17 +108,13 @@ class InvitesClient(object):
 
         :param note: Additional notes on the user
         :type  note: ``str``
-
-        :return: An instance :class:`Invite`
-        :rtype: :class:`Invite`
         """
         data = {
             'data': {
                 'note': note
             }
         }
-        invite = self.client.put('invites/{0}'.format(id), data=data)
-        return self._to_invite(invite['data'])
+        self.client.put('invites/{0}'.format(id), data=data)
 
     def cancel_invite(self, id):
         """

--- a/pluralsight/licensing/users.py
+++ b/pluralsight/licensing/users.py
@@ -89,9 +89,6 @@ class UsersClient(object):
 
         :param note: Additional notes on the user
         :type  note: ``str``
-
-        :return: An instance :class:`User`
-        :rtype: :class:`User`
         """
         data = {
             'data': {
@@ -99,8 +96,7 @@ class UsersClient(object):
                 'note': note
             }
         }
-        user = self.client.put('users/{0}'.format(id), data=data)
-        return self._to_user(user['data'])
+        self.client.put('users/{0}'.format(id), data=data)
 
     def delete_user(self, id):
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.1.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ test_requirements = [
 
 setup(
     name='pluralsight',
-    version='1.0.0',
+    version='1.1.0',
     description="Pluralsight client library for API management",
     long_description=readme + '\n\n' + history,
     author="Anthony Shaw",

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -119,15 +119,9 @@ def test_update_invite():
     special_adapter = Adapter('tests/fixtures')
     client.session.mount('https://app.pluralsight.com', special_adapter)
 
-    invite = client.invites.update_invite("bc30c000-eeee-11e6-8088-111111111111",
-                                          "test note")
-    assert invite.id == "bc30c000-eeee-11e6-8088-111111111111"
-    assert invite.email == 'a.guy@test.com'
-    assert invite.team_id is None
-    assert invite.note == 'Services'
-    assert invite.send_date.timestamp == 1483488000
-    assert invite.expires_on.timestamp == 1487376000
-
+    client.invites.update_invite("bc30c000-eeee-11e6-8088-111111111111",
+                                 "test note")
+    assert True
 
 def test_cancel_invite():
     """

--- a/tests/test_licensing_client.py
+++ b/tests/test_licensing_client.py
@@ -107,7 +107,7 @@ def test_post_bad_request():
 def test_put_request():
     with mock_session_with_class(client.session, TestMockClient, TEST_URL):
         response = client.put('put')
-        assert response['good']
+        assert response is None
 
 
 def test_put_bad_request():

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -112,10 +112,10 @@ def test_update_user():
     special_adapter = Adapter('tests/fixtures')
     client.session.mount('https://app.pluralsight.com', special_adapter)
 
-    user = client.users.update_user(id="3d4a29f7-aedc-46b8-bada-f84d04f98679",
-                                    team_id="1234512-aedc-46b8-bada-f84d04f98679",
-                                    note="test note")
-    assert user.id == "3d4a29f7-aedc-46b8-bada-f84d04f98679"
+    client.users.update_user(id="3d4a29f7-aedc-46b8-bada-f84d04f98679",
+                             team_id="1234512-aedc-46b8-bada-f84d04f98679",
+                             note="test note")
+    assert True
 
 
 def test_delete_user():


### PR DESCRIPTION
Requests to the API respond with a 204 (no content) and the API client will try and decode an empty string.

This is broken for the update_user method as well as some others.